### PR TITLE
Java Issue 13: NokiaN9\d fail to match - return N9-00 instead

### DIFF
--- a/resources/BuilderDataSource.xml
+++ b/resources/BuilderDataSource.xml
@@ -12185,7 +12185,7 @@
     <device id="Nokia N70">
       <list>
         <value>Nokia</value>
-        <value>n70</value>
+        <value>N70</value>
       </list>
     </device>
     <device id="Nokia1680c">
@@ -12281,19 +12281,19 @@
     <device id="Nokia N80">
       <list>
         <value>Nokia</value>
-        <value>n80</value>
+        <value>N80</value>
       </list>
     </device>
     <device id="NokiaN81">
       <list>
         <value>Nokia</value>
-        <value>n81</value>
+        <value>N81</value>
       </list>
     </device>
     <device id="NokiaN82">
       <list>
         <value>Nokia</value>
-        <value>n82</value>
+        <value>N82</value>
       </list>
     </device>
     <device id="Nokia3109c">
@@ -12407,7 +12407,7 @@
     <device id="Nokia N93">
       <list>
         <value>Nokia</value>
-        <value>n93</value>
+        <value>N93</value>
       </list>
     </device>
     <device id="Nokia 7373">
@@ -12419,7 +12419,7 @@
     <device id="Nokia N91">
       <list>
         <value>Nokia</value>
-        <value>n91</value>
+        <value>N91</value>
       </list>
     </device>
     <device id="NokiaC6-01">
@@ -12431,7 +12431,7 @@
     <device id="NokiaN92">
       <list>
         <value>Nokia</value>
-        <value>n92</value>
+        <value>N92</value>
       </list>
     </device>
     <device id="NokiaC6-00">
@@ -12449,7 +12449,7 @@
     <device id="Nokia N90">
       <list>
         <value>Nokia</value>
-        <value>n90</value>
+        <value>N90</value>
       </list>
     </device>
     <device id="Nokia3595">
@@ -12461,13 +12461,13 @@
     <device id="NokiaN97">
       <list>
         <value>Nokia</value>
-        <value>n97</value>
+        <value>N97</value>
       </list>
     </device>
     <device id="NokiaN95">
       <list>
         <value>Nokia</value>
-        <value>n95</value>
+        <value>N95</value>
       </list>
     </device>
     <device id="Nokia5320">
@@ -12479,7 +12479,7 @@
     <device id="NokiaN96">
       <list>
         <value>Nokia</value>
-        <value>n96</value>
+        <value>N96</value>
       </list>
     </device>
     <device id="Nokia2355">
@@ -12869,7 +12869,7 @@
     <device id="NokiaN73-1">
       <list>
         <value>Nokia</value>
-        <value>n73-1</value>
+        <value>N73-1</value>
       </list>
     </device>
     <device id="Nokia3250">
@@ -12929,19 +12929,19 @@
     <device id="NokiaN79-1">
       <list>
         <value>Nokia</value>
-        <value>n79-1</value>
+        <value>N79-1</value>
       </list>
     </device>
     <device id="NokiaN95_8GB-3">
       <list>
         <value>Nokia</value>
-        <value>n95_8gb-3</value>
+        <value>N95_8gb-3</value>
       </list>
     </device>
     <device id="NokiaN79-3">
       <list>
         <value>Nokia</value>
-        <value>n79-3</value>
+        <value>N79-3</value>
       </list>
     </device>
     <device id="Nokia2260">
@@ -12959,7 +12959,7 @@
     <device id="NokiaN97i">
       <list>
         <value>Nokia</value>
-        <value>n97i</value>
+        <value>N97i</value>
       </list>
     </device>
     <device id="Nokia8265">
@@ -13193,7 +13193,7 @@
     <device id="NokiaN95_8GB">
       <list>
         <value>Nokia</value>
-        <value>n95_8gb</value>
+        <value>N95_8gb</value>
       </list>
     </device>
     <device id="Nokia8800e">
@@ -13259,7 +13259,7 @@
     <device id="NokiaN92-2">
       <list>
         <value>Nokia</value>
-        <value>n92-2</value>
+        <value>N92-2</value>
       </list>
     </device>
     <device id="Nokia7210Supernova">
@@ -13301,7 +13301,7 @@
     <device id="NokiaN96-1">
       <list>
         <value>Nokia</value>
-        <value>n96-1</value>
+        <value>N96-1</value>
       </list>
     </device>
     <device id="Nokia6110Navigator">
@@ -13685,7 +13685,7 @@
     <device id="NokiaN97-4">
       <list>
         <value>Nokia</value>
-        <value>n97-4</value>
+        <value>N97-4</value>
       </list>
     </device>
     <device id="Nokia7710">
@@ -13781,7 +13781,7 @@
     <device id="NokiaN70-1">
       <list>
         <value>Nokia</value>
-        <value>n70-1</value>
+        <value>N70-1</value>
       </list>
     </device>
     <device id="Nokia8910">
@@ -13865,7 +13865,7 @@
     <device id="NokiaN93i">
       <list>
         <value>Nokia</value>
-        <value>n93i</value>
+        <value>N93i</value>
       </list>
     </device>
     <device id="Nokia1100">
@@ -14081,7 +14081,7 @@
     <device id="NokiaN86-1">
       <list>
         <value>Nokia</value>
-        <value>n86-1</value>
+        <value>N86-1</value>
       </list>
     </device>
     <device id="Nokia7900">


### PR DESCRIPTION
This is for the issue I accidentally posted to the java library's page: https://github.com/OpenDDRdotORG/OpenDDR-Java/issues/13
